### PR TITLE
fix: inconsistent username/password in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   postgres:
     image: postgres:13
     environment:
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: admin
+      POSTGRES_USER: notesadmin
+      POSTGRES_PASSWORD: password
       POSTGRES_DB: notesapi
     ports:
       - '5432:5432'


### PR DESCRIPTION
DB setup should use notesadmin/password, but in docker-compose file, the initial value is admin/admin, so we can't run the seed.