### PR TITLE
Fixes docker-compose & pg initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:14.15.3
 
-RUN mkdir -p /opt/notes-app
 WORKDIR /opt/notes-app
 
 COPY package.json package-lock.json ./
 
 RUN npm install
 
-CMD ["npm", "run", "start"]
+COPY . .
+
+ENTRYPOINT [ "npm", "run" ]
+CMD [ "start:prod" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN npm install
 COPY . .
 
 ENTRYPOINT [ "npm", "run" ]
-CMD [ "start:prod" ]
+CMD [ "start" ]

--- a/credentials.js
+++ b/credentials.js
@@ -1,0 +1,3 @@
+const credentials = require('./credentials.json');
+credentials['host'] = process.env.DB_HOST || credentials['host'];
+module.exports = credentials;

--- a/credentials.js
+++ b/credentials.js
@@ -1,3 +1,7 @@
-const credentials = require('./credentials.json');
-credentials['host'] = process.env.DB_HOST || credentials['host'];
-module.exports = credentials;
+module.exports = {
+  host: process.env.DB_HOST || 'localhost',
+  database: 'notesapi',
+  user: 'notesadmin',
+  password: 'password',
+  port: '5432',
+};

--- a/credentials.json
+++ b/credentials.json
@@ -1,7 +1,0 @@
-{
-  "host": "localhost",
-  "database": "notesapi",
-  "user": "notesadmin",
-  "password": "password",
-  "port": "5432"
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - ./scripts:/opt/notes-app/scripts
       - ./server:/opt/notes-app/server
       - ./src:/opt/notes-app/src
-      - ./credentials.json:/opt/notes-app/credentials.json
       - ./credentials.js:/opt/notes-app/credentials.js
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
   notes-app:
     build:
       context: .
-    command:
-      - start
     depends_on:
       - postgres
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - postgres
     ports:
       - '4000:4000'
-    network_mode: host
     volumes:
     - ./notes:/opt/notes-app/notes
     - ./public:/opt/notes-app/public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,17 +15,22 @@ services:
   notes-app:
     build:
       context: .
+    command:
+      - start
     depends_on:
       - postgres
     ports:
       - '4000:4000'
+    environment:
+      DB_HOST: postgres
     volumes:
-    - ./notes:/opt/notes-app/notes
-    - ./public:/opt/notes-app/public
-    - ./scripts:/opt/notes-app/scripts
-    - ./server:/opt/notes-app/server
-    - ./src:/opt/notes-app/src
-    - ./credentials.json:/opt/notes-app/credentials.json
+      - ./notes:/opt/notes-app/notes
+      - ./public:/opt/notes-app/public
+      - ./scripts:/opt/notes-app/scripts
+      - ./server:/opt/notes-app/server
+      - ./src:/opt/notes-app/src
+      - ./credentials.json:/opt/notes-app/credentials.json
+      - ./credentials.js:/opt/notes-app/credentials.js
 
 volumes:
   db:

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -2,16 +2,12 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    CREATE ROLE notesadmin WITH LOGIN PASSWORD 'password';
-    ALTER ROLE notesadmin WITH SUPERUSER;
-    ALTER DATABASE notesapi OWNER TO notesadmin;
-
-    DROP TABLE IF EXISTS notes;
-    CREATE TABLE notes (
-      id SERIAL PRIMARY KEY,
-      created_at TIMESTAMP NOT NULL,
-      updated_at TIMESTAMP NOT NULL,
-      title TEXT,
-      body TEXT
-    );
+  DROP TABLE IF EXISTS notes;
+  CREATE TABLE notes (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    title TEXT,
+    body TEXT
+  );
 EOSQL

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -13,7 +13,7 @@ const path = require('path');
 const {Pool} = require('pg');
 const {readdir, unlink, writeFile} = require('fs/promises');
 const startOfYear = require('date-fns/startOfYear');
-const credentials = require('../credentials.json');
+const credentials = require('../credentials');
 
 const NOTES_PATH = './notes';
 const pool = new Pool(credentials);

--- a/server/api.server.js
+++ b/server/api.server.js
@@ -29,7 +29,7 @@ const React = require('react');
 const ReactApp = require('../src/App.server').default;
 
 // Don't keep credentials in the source tree in a real app!
-const pool = new Pool(require('../credentials.json'));
+const pool = new Pool(require('../credentials'));
 
 const PORT = 4000;
 const app = express();

--- a/src/db.server.js
+++ b/src/db.server.js
@@ -7,7 +7,7 @@
  */
 
 import {Pool} from 'react-pg';
-import credentials from '../credentials.json';
+import credentials from '../credentials';
 
 // Don't keep credentials in the source tree in a real app!
 export const db = new Pool(credentials);


### PR DESCRIPTION
**Expected behavior**

```
$ git clone repo && cd repo
$ docker-compose up --build
navigate to localhost:4000
.. works ..
```

**Actual behavior**

 - `./scripts/init_db.sh` is not executable (`/bin/bash: bad interpreter: Permission denied`)
 - same script fails because user is already created, only table creation is necessary.
 - going to (localhost,0.0.0.0):4000 on host machine does not work for me w/ Docker Desktop on Mac, not sure if that was the intent here?

Test with:

```
$ docker-compose down -v # remove volumes
$ docker-compose up --build
```