### PR TITLE
server: use fs.promises instead of fs/promises

### DIFF
--- a/server/api.server.js
+++ b/server/api.server.js
@@ -21,7 +21,7 @@ babelRegister({
 const express = require('express');
 const compress = require('compression');
 const {readFileSync} = require('fs');
-const {unlink, writeFile} = require('fs/promises');
+const {unlink, writeFile} = require('fs').promises;
 const {pipeToNodeWritable} = require('react-server-dom-webpack/writer');
 const path = require('path');
 const {Pool} = require('pg');


### PR DESCRIPTION
With this change, as well as a change to react-fs, this repo will be able to support Node.js 12 (tested locally).

I can't seem to find the repo for react-fs though to propose the change  ¯\\\_(ツ)\_/¯