### PR TITLE
fix: JSON.parse fails in react-fetch

### DIFF
--- a/server/api.server.js
+++ b/server/api.server.js
@@ -174,7 +174,7 @@ app.get(
     const {rows} = await pool.query('select * from notes where id = $1', [
       req.params.id,
     ]);
-    res.json(rows[0]);
+    res.json(rows[0] || "null");
   })
 );
 


### PR DESCRIPTION
# JSON.parse fails in react-fetch

JSON.parse (empty data) doesn't work properly when I get empty data.
In react-fetch, I get Uncaught Syntax Error.

```
fetch(`http://localhost:4000/notes/-1`)
```

- api.server.js
  - GET: `/notes/:id`

> res.json(rows[0]);

Just escape it like this

```
res.json(rows[0] || "null");
```

https://stackoverflow.com/questions/9158665/json-parse-fails-in-google-chrome