### PR TITLE
Fix Node.js version to lts-hydrogen for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:14.15.3
+FROM node:lts-hydrogen
 
 WORKDIR /opt/notes-app
 
 COPY package.json package-lock.json ./
 
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 COPY . .
 


### PR DESCRIPTION
Without this, running with Docker tries to run in Node.js 14 which doesn't have the Fetch API.