### PR TITLE
fix: issue of "fetch is not defined" when using docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 
 # vscode
 .vscode
+
+# webide
+.gitpod.yml

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.18.2",
     "html-webpack-plugin": "5.5.0",
     "marked": "^4.2.12",
+    "node-fetch": "^2.6.11",
     "nodemon": "^2.0.21",
     "pg": "^8.10.0",
     "react": "18.3.0-next-1308e49a6-20230330",

--- a/server/api.server.js
+++ b/server/api.server.js
@@ -22,11 +22,16 @@ const express = require('express');
 const compress = require('compression');
 const {readFileSync} = require('fs');
 const {unlink, writeFile} = require('fs').promises;
+const nodefetch = require('node-fetch');
 const {renderToPipeableStream} = require('react-server-dom-webpack/server');
 const path = require('path');
 const {Pool} = require('pg');
 const React = require('react');
 const ReactApp = require('../src/App').default;
+
+// polyfill `fetch` on server
+globalThis.fetch = globalThis.fetch || nodefetch;
+
 
 // Don't keep credentials in the source tree in a real app!
 const pool = new Pool(require('../credentials'));


### PR DESCRIPTION
Because fetch does not exist in early version of node (like 14.x)

Then if running up by docker compose, we see errors below,
```
Application Error
ReferenceError: fetch is not defined
    at Note (/opt/notes-app/src/Note.js:36:24)
    at attemptResolveElement (/opt/notes-app/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js:1597:18)
    at resolveModelToJSON (/opt/notes-app/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js:1883:21)
    at Object.toJSON (/opt/notes-app/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js:1421:14)
    at stringify (<anonymous>)
    at processModelChunk (/opt/notes-app/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js:258:14)
    at retryTask (/opt/notes-app/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js:2166:26)
    at performWork (/opt/notes-app/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js:2213:7)
    at async_hooks.js:313:14
    at AsyncResource.runInAsyncScope (async_hooks.js:197:9)
    at AsyncLocalStorage.run (async_hooks.js:311:35)
    at Immediate.<anonymous> (/opt/notes-app/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js:2313:29)
    at processImmediate (internal/timers.js:461:21)
    at process.callbackTrampoline (internal/async_hooks.js:131:14)
```

<img width="1216" alt="image" src="https://github.com/reactjs/server-components-demo/assets/5611770/b43bc721-138c-413f-9103-95e3d93c9b6b">
